### PR TITLE
Remove padding from code snippets

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,7 +141,6 @@ ul {
 
 code {
     background-color: rgba(255, 255, 255, 0.1);
-    padding: 0.2rem 0.4rem;
     border-radius: 4px;
     font-family: monospace;
 }


### PR DESCRIPTION
## before

![image](https://github.com/user-attachments/assets/d3adab46-eb2a-4b0c-a7f6-a2a244216bcb)

## after

![image](https://github.com/user-attachments/assets/c9abb7cc-2b20-47a5-94d7-284d0449e77d)


@itubetw objections? Ideas? I think you added that padding. It is overlapping on my machine.